### PR TITLE
Bug fix for newest iOS and crash of Observer

### DIFF
--- a/ios/CouchbaseEvents/AppDelegate.h
+++ b/ios/CouchbaseEvents/AppDelegate.h
@@ -7,11 +7,12 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "CouchbaseEvents.h"
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
-
+@property CouchbaseEvents* cbevents;
 
 @end
 

--- a/ios/CouchbaseEvents/AppDelegate.m
+++ b/ios/CouchbaseEvents/AppDelegate.m
@@ -7,7 +7,7 @@
 //
 
 #import "AppDelegate.h"
-#import "CouchbaseEvents.h"
+
 
 @interface AppDelegate ()
 
@@ -19,8 +19,8 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for customization after application launch.
     
-    CouchbaseEvents* cbevents = [[CouchbaseEvents alloc] init];
-    [cbevents helloCBL];
+    _cbevents = [[CouchbaseEvents alloc] init];
+    [_cbevents helloCBL];
     
     return YES;
 }

--- a/ios/CouchbaseEvents/CouchbaseEvents.h
+++ b/ios/CouchbaseEvents/CouchbaseEvents.h
@@ -12,5 +12,5 @@
 @interface CouchbaseEvents : NSObject
 
 - (BOOL) helloCBL;
-
+@property CBLLiveQuery* liveQuery;
 @end

--- a/ios/CouchbaseEvents/CouchbaseEvents.m
+++ b/ios/CouchbaseEvents/CouchbaseEvents.m
@@ -25,9 +25,9 @@
     
     [self outputOrderedByDate];
     
-    CBLLiveQuery* liveQuery = [[[self getView] createQuery] asLiveQuery];
-    [liveQuery addObserver: self forKeyPath:@"rows" options:0 context: NULL];
-    [liveQuery start];
+    _liveQuery = [[[self getView] createQuery] asLiveQuery];
+    [_liveQuery addObserver: self forKeyPath:@"rows" options:0 context: NULL];
+    [_liveQuery start];
  
     return NO;
 }

--- a/ios/CouchbaseEvents/Info.plist
+++ b/ios/CouchbaseEvents/Info.plist
@@ -22,6 +22,16 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>127.0.0.1</key>
+			<string></string>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
Hi, I tried to follow your tutorial and failed to do the LiveQuery at the last step, I find out that it's because the newest iOS will release the ptr after the function run . So thing is like this:

Add self to observer in `helloCBL`  :

```ObjC
CBLLiveQuery* _liveQuery = [[[self getView] createQuery] asLiveQuery];
[_liveQuery addObserver: self forKeyPath:@"rows" options:0 context: NULL];
[_liveQuery start];
```

And just call `helloCBL` in `didFinishLaunchingWithOptions`
```ObjC
CouchbaseEvents *_cbevents = [[CouchbaseEvents alloc] init];
[_cbevents helloCBL];
```

But the ptr _cbevents is released after `didFinishLaunchingWithOptions` is returned , so the observer is no longer exist .

I moved it out and old it on `AppDelegate` , so it won't be released.

Sorry I am not professional ObjC developer, so I don't sure if this fix is elegant or not for you. 

Also, the newest iOS don't allow you to use "http" sting directly in you code now, you need to add some fields in your Info.plist file.

Pls update your tutorial documents. Your products are so good , so pls make the tutorials updated so more people can enjoy your products. 